### PR TITLE
fix(security): add explicit permissions to workflow files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   config:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,9 @@ on:
           - testpypi
           - pypi
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -9,6 +9,9 @@ on:
     - cron: '0 9 * * 1'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   audit:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -4,6 +4,10 @@ on:
     - cron: '42 4 * * *'
   workflow_dispatch:
 
+permissions:
+  issues: write
+  pull-requests: write
+
 jobs:
   stale:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

This PR adds explicit permissions to all GitHub Actions workflows to follow the principle of least privilege and resolve CodeQL security alerts.

## Changes

| Workflow | Permissions Added | Reason |
|----------|-------------------|--------|
| `main.yml` | `contents: read` | Required for checkout and script execution |
| `security.yml` | `contents: read` | Required for checkout and pip-audit |
| `stale.yml` | `issues: write`, `pull-requests: write` | Required for stale action to manage issues/PRs |
| `publish.yml` | `contents: read` | Required for checkout (publish jobs already have `id-token: write`) |

## Security Alerts Resolved

This PR resolves the following CodeQL security alerts:
- #1, #3, #8 - `main.yml` missing permissions
- #7 - `security.yml` missing permissions  
- #9 - `stale.yml` missing permissions
- #11 - `publish.yml` missing permissions

## References

- [GitHub Actions Security Hardening](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions)
- CodeQL Rule: `actions/missing-workflow-permissions`